### PR TITLE
improved comparison UX, restrict 3D support, add file category service

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,23 @@
+May 20, 2025
+
+### 1.Fixed an issue in the comparison popup where users could mistakenly select the same file as both base and comparison file causing UI confusion.
+### 2. Disabled the "Compare" option in the burger menu when a 3D file is opened, aligning with feature restrictions.
+### 3. Updated the "Compare Document" popup to exclude unsupported 3D files from the dropdown for better user clarity.
+### 4. Introduced a reusable file category service with a centralized enum and helper methods to streamline type-based operations.
+### 5. Resolved issue where the Grayscale slider tool in the comparison window did not toggle correctly when switching between normal and comparison views. Also added the missing tooltip for better user guidance.
+### 6. Resolved issue where comparison window's toolbar being shown on other windows even if comparison window closed or not active. streamline the behavior aviour of comparison window's toolbar to only appear in compare mode
+
+Updated and new files
+
+src\app\components\compare\create-comparison\create-comparison.component.ts
+src\app\components\compare\top-nav-menu\top-nav-menu.component.ts
+src\app\components\compare\top-nav-menu\top-nav-menu.component.html
+src\app\services\file-category.service.ts
+src\app\shared\enums\file-category.ts
+src\app\components\bottom-toolbar\bottom-toolbar.component.html
+
+
+
 May 16, 2025
 
 ### 1. Implemented locked aspect ratio for image type annoations.

--- a/src/app/components/bottom-toolbar/bottom-toolbar.component.html
+++ b/src/app/components/bottom-toolbar/bottom-toolbar.component.html
@@ -169,11 +169,12 @@
                     </svg>
                     <span class="tooltip-text tooltip-top">Fit height</span>
                 </li>
-                <li *ngIf="(guiConfig$ | async).enableGrayscaleButton" (click)="onActionSelect('GRAYSCALE')" [class.selected]="state?.isActionSelected['GRAYSCALE']">
+                <li *ngIf="(guiConfig$ | async).enableGrayscaleButton" (click)="onActionSelect('GRAYSCALE')" [class.selected]="state?.isActionSelected['GRAYSCALE']" class="tooltip">
                     <svg width="15" height="18" viewBox="0 0 15 18" fill="none" xmlns="http://www.w3.org/2000/svg">
                         <path d="M13.9 11.3684C13.9 14.6694 11.0656 17.4 7.5 17.4C3.9344 17.4 1.1 14.6694 1.1 11.3684C1.1 10.3204 1.49115 9.11659 2.12834 7.86617C2.76129 6.62407 3.61198 5.38407 4.47361 4.27626C5.33375 3.17036 6.19543 2.20812 6.84272 1.5219C7.10113 1.24795 7.32485 1.01853 7.5 0.842132C7.67515 1.01853 7.89887 1.24795 8.15728 1.5219C8.80457 2.20812 9.66625 3.17036 10.5264 4.27626C11.388 5.38407 12.2387 6.62407 12.8717 7.86617C13.5088 9.11659 13.9 10.3204 13.9 11.3684Z" stroke="#333C4E" stroke-width="1.2"/>
                         <path d="M14 11.3684C14 14.5732 11.378 17.2408 8.00001 17.4822L8.00001 17.4789L8.00005 16.0577L8.00009 11.3684L8.00005 3.90789L8.00002 1.21148C8.07309 1.28765 8.1499 1.36833 8.23003 1.45328C8.87881 2.14109 9.74271 3.10578 10.6053 4.21487C11.4692 5.32554 12.3239 6.57105 12.9608 7.82076C13.6011 9.07742 14 10.2977 14 11.3684Z" fill="#333C4E" stroke="#333C4E"/>
                     </svg>
+                    <span class="tooltip-text tooltip-top">Grayscale Slider</span>
                 </li>
                 <li *ngIf="state?.isActionSelected['GRAYSCALE']" class="slider-grayscale">
                     <ngx-slider

--- a/src/app/components/compare/create-comparison/create-comparison.component.ts
+++ b/src/app/components/compare/create-comparison/create-comparison.component.ts
@@ -7,6 +7,8 @@ import { TopNavMenuService } from '../../top-nav-menu/top-nav-menu.service';
 import { RxCoreService } from 'src/app/services/rxcore.service';
 import { Subscription } from 'rxjs';
 import { IComparison } from 'src/rxcore/models/IComparison';
+import { FileCategoryService } from 'src/app/services/file-category.service';
+import { FileCategory } from 'src/app/shared/enums/file-category';
 
 @Component({
   selector: 'rx-create-comparison',
@@ -41,12 +43,23 @@ export class CreateComparisonComponent implements OnInit, OnDestroy {
     private readonly compareService: CompareService,
     private readonly colorHelper: ColorHelper,
     private readonly fileGaleryService: FileGaleryService,
-    private readonly topNavMenuService: TopNavMenuService) {}
+    private readonly topNavMenuService: TopNavMenuService,
+    private readonly fileCategoryService: FileCategoryService) {}
 
   private _init(setOtherFile: boolean = false): void {
     const fileList = RXCore.getOpenFilesList().filter(file => !this.compareService.findComparisonByFileName(file.name));
     this.activeFile = fileList?.find(file => file.isActive);
-    this.fileOptions = fileList?.map(file => ({ value: file, label: file.name }));
+
+    //Skip files which are already selected/active in viewer, it is not a good idea to let user perform comparison with same file
+    //Exclude 3D files from comparison 
+    const threeDFiles = this.fileCategoryService.getCategories(fileList, FileCategory.ThreeD);
+    if (threeDFiles && threeDFiles.length > 0) {
+    this.fileOptions = fileList?.filter(file => !threeDFiles.map(x => x.id).includes(file.id));
+    }else{
+      this.fileOptions = fileList;
+    }
+
+    this.fileOptions = this.fileOptions?.filter(file => !file.isActive ).map(file => ({ value: file, label: file.name }));
     if (setOtherFile && this.fileOptions?.length) {
       this.otherFile = this.fileOptions[this.fileOptions.length - 1];
     }

--- a/src/app/components/top-nav-menu/top-nav-menu.component.html
+++ b/src/app/components/top-nav-menu/top-nav-menu.component.html
@@ -506,7 +506,7 @@
 
             *ngIf="
               guiConfig.canCompare &&
-              !guiConfig.disableBurgerMenuCompare
+              !guiConfig.disableBurgerMenuCompare && !state.is3D
             "
             role="option"
             tabindex="0"

--- a/src/app/components/top-nav-menu/top-nav-menu.component.ts
+++ b/src/app/components/top-nav-menu/top-nav-menu.component.ts
@@ -106,6 +106,15 @@ export class TopNavMenuComponent implements OnInit {
           this.onModeChange(value, false);
         }
       }
+      else{
+            //Hide compare toolbar if comparison window is closed Or not active
+            this.onModeChange(false, false);
+
+            //Disable tools which enabled for comparison
+            this.rxCoreService.setGuiConfig({
+            enableGrayscaleButton: this.compareService.isComparisonActive
+        });
+      }
     });
 
     this.rxCoreService.guiMode$.subscribe(mode => {

--- a/src/app/services/file-category.service.ts
+++ b/src/app/services/file-category.service.ts
@@ -1,0 +1,62 @@
+import { Injectable } from '@angular/core';
+import { FileCategory } from '../shared/enums/file-category';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class FileCategoryService {
+  private extensionMap: { [key: string]: FileCategory } = {
+     // 2D CAD
+  '.dwg': FileCategory.TwoD,
+  '.dgn': FileCategory.TwoD,
+  '.idw': FileCategory.TwoD,
+  '.plt': FileCategory.TwoD,
+  '.gbr': FileCategory.TwoD,
+  '.tif': FileCategory.TwoD,
+  '.tiff': FileCategory.TwoD,
+  '.jpg': FileCategory.TwoD,
+  '.jpeg': FileCategory.TwoD,
+  '.png': FileCategory.TwoD,
+
+  // 3D Models
+  '.stp': FileCategory.ThreeD,
+  '.step': FileCategory.ThreeD,
+  '.ifc': FileCategory.ThreeD,
+  '.igs': FileCategory.ThreeD,
+  '.ipt': FileCategory.ThreeD,
+
+  // PDF
+  '.pdf': FileCategory.PDF,
+
+  // Office
+  '.doc': FileCategory.Office,
+  '.docx': FileCategory.Office,
+  '.xlsx': FileCategory.Office,
+  '.xls': FileCategory.Office,
+  '.ppt': FileCategory.Office,
+  '.pptx': FileCategory.Office
+  };
+
+  getCategory(fileName: string):  FileCategory {
+    const extension = this.getFileExtension(fileName);
+    return this.extensionMap[extension] || 'Unknown';
+  }
+
+getCategories(
+  files: { id: string; name: string }[],
+  fileCategory?: FileCategory | null
+): { id: string; name: string; category: FileCategory }[] {
+  return files
+    .map(file => ({
+      id: file.id,
+      name: file.name,
+      category: this.getCategory(file.name)
+    }))
+    .filter(file => !fileCategory || file.category === fileCategory);
+}
+
+  private getFileExtension(fileName: string): string {
+    const lastDot = fileName.lastIndexOf('.');
+    return lastDot !== -1 ? fileName.substring(lastDot).toLowerCase() : '';
+  }
+}

--- a/src/app/shared/enums/file-category.ts
+++ b/src/app/shared/enums/file-category.ts
@@ -1,0 +1,7 @@
+export enum FileCategory  {
+  TwoD = '2D',
+  ThreeD = '3D',
+  PDF = 'PDF',
+  Office = 'Office',
+  Unknown = 'Unknown'
+}


### PR DESCRIPTION
Hi, following is the summary of work completed in this PR:

##  Comparison Popup Validation

**Issue Fixed:**
Users could accidentally select the same file as both the base and comparison file in the "Compare Document" popup, which led to UI confusion and inconsistent behavior. Due to this both files in the compare tab gets activated.
**Solution:**
Implemented a validation check to prevent selecting the same file for both roles. Now, once a file is chosen as the base, it is excluded from the comparison dropdown to ensure clarity and logical operation.

## Disable Compare Option for 3D Files

**Issue Fixed:**
The "Compare" option was visible in the burger menu even when a 3D file was opened, which is not supported for comparison.
**Solution:**
Conditionally disabled the "Compare" option in the burger menu for 3D files to align the UI behavior with actual feature limitations.

## Exclude 3D Files from Compare Popup

**Issue Fixed:**
3D files were being listed in the "Compare Document" popup despite being unsupported for comparison, confusing users.
**Solution:**
Updated the logic to filter out 3D files from the comparison file dropdowns to ensure only valid  files are displayed.
Created a centralized, reusable `FileCategoryService` that provides helper methods to identify file types based on extension.
**Details:**

* Introduced a `FileCategory` enum to maintain type consistency across the app.
* The service supports both single and batch file category identification.
* This will improve maintainability and reduce logic duplication across components.

---

## Grayscale Tool Toggle Fix

**Issue Fixed:**
The Grayscale slider tool in the comparison mode didn’t toggle properly when switching between normal and comparison views.
**Solution:**
Fixed the state handling so that the Grayscale tool is enabled/disabled appropriately when switching views. Also added a tooltip to improve usability and clarity for users.

##  Comparison Toolbar Visibility

**Issue Fixed:**
The comparison window's toolbar was being shown in other contexts even when the comparison mode was not active or had been closed.
**Solution:**
Streamlined the toolbar behavior to ensure it only appears when the comparison window is actively in use, improving UI cleanliness and reducing confusion.