### PR TITLE
Feature/cad files preselection

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,32 @@
+June 26, 2025
+### 1. Developed file-metadata-modal component to display metadata for CAD files only.
+### 2. Implemented FileMetadataService to retrieve file metadata from the backend.
+### 3. Enhanced handleFileSelect method in the File Gallery component to support CAD file pre-selection.
+### 4. Updated onGuiVectorLayers and onGuiVectorBlocks methods to reflect user-selected layers and blocks.
+### 5. Introduced FileMetadata interface to map API response structure accurately.
+### 6. Created FilePreselectionService to emit selected CAD files and trigger file opening from top-nav-component.
+### 7. Integrated new API endpoint to rxconfig.js SampleFileMetadata to fetch metadata details for selected files.
+
+updated files
+
+src\app.component.ts
+src\app.module.ts
+src\app\components\file-galery-component.ts
+src\style.scss
+src\app\components\side-nav-menu\blocks
+src\app\components\side-nav-menu\vector-layers
+src\app\components\top-nav-menu.component.ts
+src\assets\scripts\rxconfig.js
+
+new files
+
+src\app\components\file-metadata-modal.component.html
+src\app\components\file-metadata-modal.component.ts
+src\app\components\file-metadata-modal.component.scss
+src\app\models\fileMetadata.interface.ts
+src\app\services\file-metadata.service.ts
+src\app\services\file-preselection.service.ts
+
 June 16, 2025
 
 ### 1. Updated Foxit to new version 10.

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -758,13 +758,82 @@ export class AppComponent implements AfterViewInit {
 
     });
 
-    RXCore.onGuiVectorLayers((layers) => {
-      this.rxCoreService.setGuiVectorLayers(layers);
+    function getSelectionsFromLocalStorage() {
+      let selectedLayers = [];
+      let selectedBlocks = [];
+      if (typeof (Storage) !== "undefined") {
+        const layers = localStorage.getItem("selectedLayers");
+        const blocks = localStorage.getItem("selectedBlocks");
+        if (layers) {
+          try {
+            selectedLayers = JSON.parse(layers);
+          } catch (e) {
+            selectedLayers = [];
+          }
+        }
+        if (blocks) {
+          try {
+            selectedBlocks = JSON.parse(blocks);
+          } catch (e) {
+            selectedBlocks = [];
+          }
+        }
+      }
+      return { selectedLayers, selectedBlocks };
+    }
+
+   RXCore.onGuiVectorLayers((layers) => {
+  const selections = getSelectionsFromLocalStorage();
+  const selectedLayers: string[] = Array.isArray(selections?.selectedLayers)
+    ? selections.selectedLayers
+    : [];
+
+  if (selectedLayers.length > 0 && layers.length > 0) {
+    // Set state = false for unselected layers
+    layers.forEach(layer => {
+      if (!selectedLayers.includes(layer.name.trim())) {
+        layer.state = false;
+      }
     });
 
-    RXCore.onGuiVectorBlocks((blocks) => {
-      this.rxCoreService.setGuiVectorBlocks(blocks);
+    // Only show selected layers in the side nav
+    const filteredLayers = layers.filter(layer =>
+      selectedLayers.includes(layer.name.trim())
+    );
+
+    this.rxCoreService.setGuiVectorLayers(filteredLayers);
+  } else {
+    // No selected layers, show all
+    this.rxCoreService.setGuiVectorLayers(layers);
+  }
+});
+
+RXCore.onGuiVectorBlocks((blocks) => {
+  const selections = getSelectionsFromLocalStorage();
+  const selectedBlocks: string[] = Array.isArray(selections?.selectedBlocks)
+    ? selections.selectedBlocks
+    : [];
+
+  if (selectedBlocks.length > 0 && blocks.length > 0) {
+    // Set state = 0 for unselected blocks
+    blocks.forEach(block => {
+      if (!selectedBlocks.includes(block.name.trim())) {
+        block.state = 0;
+      }
     });
+
+    // Only show selected blocks in the side nav
+    const filteredBlocks = blocks.filter(block =>
+      selectedBlocks.includes(block.name.trim())
+    );
+    
+    this.rxCoreService.setGuiVectorBlocks(filteredBlocks);
+    
+  } else {
+    // No selected blocks, show all
+    this.rxCoreService.setGuiVectorBlocks(blocks);
+  }
+});
 
     RXCore.onGui3DParts((parts) => {
       this.rxCoreService.setGui3DParts(parts);

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,7 +1,7 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule, Title } from '@angular/platform-browser';
 import { HttpClientModule } from '@angular/common/http';
-
+import { MatDialogModule } from '@angular/material/dialog';
 //import { FormsModule } from '@angular/forms';
 
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
@@ -104,6 +104,7 @@ import { LoginModalComponent } from './components/user/login-modal/login-modal.c
 import { NumericRangeDirective } from "./directives/numeric-range.directive";
 import { ResizableDirective } from './directives/resizable.directive';
 import {IsPinnedPipe} from "./components/top-nav-menu/opened-files-tabs/is-pinned.pipe";
+import { FileMetadataModalComponent } from './components/file-metadata-modal/file-metadata-modal.component';
 
 const storeSchema = [
   { name: 'name', keypath: 'name', options: { unique: false } },
@@ -207,7 +208,8 @@ const dbConfig: DBConfig  = {
     LoginComponent,
     RoomPanelComponent,
     ResizableDirective,
-    LoginModalComponent
+    LoginModalComponent,
+    FileMetadataModalComponent
   ],
   imports: [
     BrowserModule,
@@ -223,6 +225,7 @@ const dbConfig: DBConfig  = {
     AngularDraggableModule,
     TreeviewModule.forRoot(),
     ToastrModule.forRoot(), // ToastrModule added
+    MatDialogModule
   ],
   providers: [ColorHelper, Title],
   bootstrap: [AppComponent],

--- a/src/app/components/file-metadata-modal/file-metadata-modal.component.html
+++ b/src/app/components/file-metadata-modal/file-metadata-modal.component.html
@@ -1,0 +1,91 @@
+<div class="file-metadata-modal">
+  <div class="modal-header">
+    <h2>File Preview & Selection</h2>
+    <button class="close-btn" (click)="onCancel()">×</button>
+  </div>
+
+  <div class="modal-content">
+    <div *ngIf="loading" class="loading">
+      <div class="spinner"></div>
+      <p>Loading file metadata...</p>
+    </div>
+
+    <div *ngIf="error" class="error">
+      <p>Failed to load file metadata. Please try again.</p>
+      <button (click)="loadMetadata()">Retry</button>
+    </div>
+
+    <div *ngIf="!loading && !error && metadata" class="metadata-content">
+      <!-- File Info Section -->
+      <div class="file-info">
+        <div class="thumbnail">
+          <img [src]="'data:image/png;base64,' + metadata.thumbnail" [alt]="metadata.filename" />
+
+        </div>
+        <div class="file-details">
+          <h3>{{ metadata.filename }}</h3>
+          <p><strong>Format:</strong> {{ metadata.format }}</p>
+          <p><strong>Size:</strong> {{ metadata.filesize }} bytes</p>
+        </div>
+      </div>
+
+      <div class="section" *ngIf="metadata.layers && metadata.layers.length > 0">
+        <div class="section-header">
+          <h4>Layers ({{ selectedLayers.length }}/{{ metadata.layers.length }})</h4>
+          <div class="section-actions">
+            <button (click)="selectAllLayers()">Select All</button>
+            <button (click)="deselectAllLayers()">Deselect All</button>
+          </div>
+        </div>
+
+        <div class="items-grid">
+          <div *ngFor="let layer of metadata.layers" class="item" [class.selected]="isLayerSelected(layer)">
+            <input type="checkbox" [checked]="isLayerSelected(layer)" (change)="toggleLayer(layer)" />
+            <span>{{ layer }}</span>
+          </div>
+        </div>
+      </div>
+      <!-- No content found -->
+      <div *ngIf="noContentFound" class="no-content">
+        No layers or blocks found for this file.
+      </div>
+
+      <!-- Only layers are missing -->
+      <div *ngIf="!noContentFound && noLayersFound" class="no-content">
+        No layers found for this file.
+      </div>
+
+      <!-- Only blocks are missing -->
+      <div *ngIf="!noContentFound && noBlocksFound" class="no-content">
+        No blocks found for this file.
+      </div>
+
+      <div class="divider"></div>
+      <!-- Blocks Section -->
+      <div class="section" *ngIf="getAllBlocks().length > 0">
+        <div class="section-header">
+          <h4>Blocks ({{ selectedBlocks.length }}/{{ getAllBlocks().length }})</h4>
+          <div class="section-actions">
+            <button (click)="selectAllBlocks()">Select All</button>
+            <button (click)="deselectAllBlocks()">Deselect All</button>
+          </div>
+        </div>
+
+        <div class="items-grid">
+          <div *ngFor="let block of getAllBlocks()" class="item" [class.selected]="isBlockSelected(block)">
+            <input type="checkbox" [checked]="isBlockSelected(block)" (change)="toggleBlock(block)" />
+            <span>{{ block }}</span>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+  <div class="validation-error" *ngIf="validationError">
+    <p>{{ validationErrorMessage }}</p>
+  </div>
+  <div class="modal-actions" *ngIf="!loading && !error && metadata">
+    <button class="btn btn-primary" (click)="onConfirm()">Open File</button>
+    <button class="btn btn-light" (click)="onCancel()">Cancel</button>
+  </div>
+</div>

--- a/src/app/components/file-metadata-modal/file-metadata-modal.component.scss
+++ b/src/app/components/file-metadata-modal/file-metadata-modal.component.scss
@@ -1,0 +1,222 @@
+.file-metadata-modal {
+  width: 620px;
+  max-width: 90vw;
+  background: #fff;
+  border-radius: 10px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.18);
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  max-height: 90vh;
+
+  .modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 16px 24px;
+    border-bottom: 1px solid #e0e0e0;
+    background-color: #fafafa;
+    border-top-left-radius: 8px;
+    border-top-right-radius: 8px;
+  }
+
+  .modal-header h2 {
+    margin: 0;
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: #333;
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  }
+
+  .modal-header .close-btn {
+    background: none;
+    border: none;
+    font-size: 1.5rem;
+    color: #999;
+    cursor: pointer;
+    transition: color 0.2s ease;
+    padding: 0 4px;
+  }
+
+  .modal-header .close-btn:hover {
+    color: #e53935;
+  }
+
+
+  .modal-content {
+    flex: 1 1 auto;
+    overflow-y: auto;
+    padding: 24px;
+    min-height: 200px;
+    max-height: 60vh;
+
+
+    .file-info {
+      display: flex;
+      align-items: center;
+      gap: 20px;
+      padding: 16px 24px;
+      background-color: #f9f9f9;
+      border-radius: 8px;
+      margin-bottom: 16px;
+      box-shadow: 0 1px 4px rgba(0, 0, 0, 0.05);
+    }
+
+    .file-info .thumbnail img {
+      width: 80px;
+      height: 80px;
+      object-fit: contain;
+      border: 1px solid #ddd;
+      border-radius: 6px;
+      background-color: #fff;
+    }
+
+    .file-info .file-details {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+
+    .file-info .file-details h3 {
+      margin: 0;
+      font-size: 1.1rem;
+      font-weight: 600;
+      color: #333;
+    }
+
+    .file-info .file-details p {
+      margin: 0;
+      font-size: 0.95rem;
+      color: #666;
+    }
+
+
+    .section {
+      margin-top: 24px;
+      padding-bottom: 16px;
+      border-bottom: 1px solid #f0f0f0;
+
+      &:last-child {
+        border-bottom: none;
+      }
+
+      .section-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+
+        h4 {
+          margin: 0;
+        }
+
+        .section-actions button {
+          margin-left: 8px;
+        }
+      }
+
+      .items-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+        gap: 10px 12px;
+        margin-top: 12px;
+        max-height: 220px;
+        overflow-y: auto;
+
+        .item {
+          display: flex;
+          align-items: center;
+          background: #f8f9fa;
+          border: 1px solid #e0e0e0;
+          border-radius: 6px;
+          padding: 6px 10px;
+          transition: box-shadow 0.2s, border 0.2s, background 0.2s;
+          cursor: pointer;
+          font-size: 0.98rem;
+
+          &.selected {
+            background: #e6f4ea;
+            border: 1.5px solid #4caf50;
+            font-weight: 600;
+            color: #256029;
+          }
+
+          &:hover {
+            box-shadow: 0 2px 8px rgba(76, 175, 80, 0.08);
+            border: 1.5px solid #81c784;
+            background: #f1f8e9;
+          }
+
+          input[type="checkbox"] {
+            margin-right: 8px;
+          }
+
+          span {
+            flex: 1;
+          }
+        }
+      }
+    }
+
+    .loading,
+    .error {
+      text-align: center;
+    }
+
+    .spinner {
+      width: 32px;
+      height: 32px;
+      border: 4px solid #eee;
+      border-top: 4px solid #888;
+      border-radius: 50%;
+      animation: spin 1s linear infinite;
+      margin: 0 auto 12px;
+    }
+
+    @keyframes spin {
+      100% {
+        transform: rotate(360deg);
+      }
+    }
+  }
+
+  .modal-actions {
+    display: flex;
+    justify-content: flex-end;
+    padding: 16px 24px;
+    border-top: 1px solid #eee;
+
+    button {
+      margin-left: 12px;
+    }
+  }
+
+  .divider {
+    height: 1px;
+    background: #f0f0f0;
+    margin: 18px 0;
+    border-radius: 1px;
+  }
+
+  .no-content {
+    text-align: center;
+    color: #ff9800;
+    font-weight: 500;
+    margin-top: 20px;
+  }
+
+  .validation-error {
+    background-color: #ffe5e5;
+    color: #b00020;
+    border: 1px solid #f5c2c7;
+    padding: 8px 12px;
+    margin: 8px auto 0 auto;
+    max-width: 400px;
+    border-radius: 6px;
+    text-align: center;
+    font-weight: 500;
+    font-size: 13.5px;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+    line-height: 1.4;
+  }
+
+}

--- a/src/app/components/file-metadata-modal/file-metadata-modal.component.spec.ts
+++ b/src/app/components/file-metadata-modal/file-metadata-modal.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { FileMetadataModalComponent } from './file-metadata-modal.component';
+
+describe('FileMetadataModalComponent', () => {
+  let component: FileMetadataModalComponent;
+  let fixture: ComponentFixture<FileMetadataModalComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [FileMetadataModalComponent]
+    });
+    fixture = TestBed.createComponent(FileMetadataModalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/file-metadata-modal/file-metadata-modal.component.ts
+++ b/src/app/components/file-metadata-modal/file-metadata-modal.component.ts
@@ -1,0 +1,190 @@
+import { Component, EventEmitter, Inject, Input, Output } from '@angular/core';
+import { FileSelectionOptions, FileMetadata, FileMetadataService } from 'src/app/services/file-metadata.service';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+@Component({
+  selector: 'app-file-metadata-modal',
+  templateUrl: './file-metadata-modal.component.html',
+  styleUrls: ['./file-metadata-modal.component.scss']
+})
+export class FileMetadataModalComponent {
+  fileName: string;
+  filePath: string = '';
+  @Output() confirmed = new EventEmitter<FileSelectionOptions>();
+  @Output() cancelled = new EventEmitter<void>();
+
+  metadata: FileMetadata | null = null;
+  loading = true;
+  error = false;
+
+  selectedLayers: string[] = [];
+  selectedBlocks: string[] = [];
+
+
+  constructor(
+    private fileMetadataService: FileMetadataService,
+    private dialogRef: MatDialogRef<FileMetadataModalComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: { fileName: string }
+  ) {
+    this.fileName = data.fileName;
+  }
+
+  ngOnInit() {
+    this.loadMetadata(this.fileName);
+  }
+
+
+  noLayersFound = false;
+  noBlocksFound = false;
+  noContentFound = false;
+
+
+
+  async loadMetadata(fileName: string): Promise<void> {
+    this.loading = true;
+    this.error = false;
+
+    try {
+      const data = await new Promise<any>((resolve, reject) => {
+        this.fileMetadataService.getFileMetadata(fileName).subscribe({
+          next: (res) => resolve(res),
+          error: (err) => reject(err)
+        });
+      });
+
+      if (!data) {
+        this.error = true;
+        console.warn('No metadata received for file:', fileName);
+        return;
+      }
+
+      const layers = Array.isArray(data.layers) ? [...data.layers] : [];
+      const layouts = Array.isArray(data.layouts) ? [...data.layouts] : [];
+
+      this.metadata = {
+        ...data,
+        layers,
+        layouts
+      };
+
+      this.selectedLayers = [...layers];
+      this.selectedBlocks = this.getAllBlocks();
+
+      if (layers.length === 0 && this.selectedBlocks.length === 0) {
+        console.warn('No layers or blocks found for this file.');
+      }
+
+      this.noLayersFound = layers.length === 0;
+      this.noBlocksFound = this.selectedBlocks.length === 0;
+      this.noContentFound = this.noLayersFound && this.noBlocksFound;
+
+    } catch (err) {
+      this.error = true;
+      console.error('Failed to load file metadata:', err);
+    } finally {
+      this.loading = false;
+    }
+  }
+
+
+
+  private getAllBlocks(): string[] {
+    if (!this.metadata?.layouts) return [];
+    return this.metadata.layouts.flatMap(layout => layout.blocks || []);
+  }
+
+
+  toggleLayer(layer: string) {
+    const index = this.selectedLayers.indexOf(layer);
+    if (index > -1) {
+      this.selectedLayers.splice(index, 1);
+    } else {
+      this.selectedLayers.push(layer);
+    }
+  }
+
+  toggleBlock(block: string) {
+    const index = this.selectedBlocks.indexOf(block);
+    if (index > -1) {
+      this.selectedBlocks.splice(index, 1);
+    } else {
+      this.selectedBlocks.push(block);
+    }
+  }
+  selectAllLayers() {
+    this.selectedLayers = [...(this.metadata?.layers || [])];
+  }
+
+  deselectAllLayers() {
+    this.selectedLayers = [];
+  }
+
+  selectAllBlocks() {
+    this.selectedBlocks = this.getAllBlocks();
+  }
+
+  deselectAllBlocks() {
+    this.selectedBlocks = [];
+  }
+  validationError: boolean = false;
+  validationErrorMessage: string = '';
+  onConfirm() {
+    const hasLayers = this.selectedLayers.length > 0;
+    const hasBlocks = this.selectedBlocks.length > 0;
+
+    const layersAvailable = (this.metadata?.layers?.length || 0) > 0;
+    const blocksAvailable = this.getAllBlocks().length > 0;
+
+
+    if (layersAvailable && blocksAvailable) {
+      if (!hasLayers && hasBlocks) {
+        this.validationError = true;
+        this.validationErrorMessage = 'Please select at least one layer before proceeding.';
+        return;
+      }
+
+      if (!hasBlocks && hasLayers) {
+        this.validationError = true;
+        this.validationErrorMessage = 'Please select at least one block before proceeding.';
+        return;
+      }
+
+      if (!hasLayers && !hasBlocks) {
+        this.validationError = true;
+        this.validationErrorMessage = 'Please select at least one layer and one block before proceeding.';
+        return;
+      }
+    }
+
+    if (layersAvailable && !blocksAvailable && !hasLayers) {
+      this.validationError = true;
+      this.validationErrorMessage = 'Please select at least one layer before proceeding.';
+      return;
+    }
+
+    if (blocksAvailable && !layersAvailable && !hasBlocks) {
+      this.validationError = true;
+      this.validationErrorMessage = 'Please select at least one block before proceeding.';
+      return;
+    }
+
+    this.validationError = false;
+    this.validationErrorMessage = '';
+    const options: FileSelectionOptions = {
+      selectedLayers: this.selectedLayers,
+      selectedBlocks: this.selectedBlocks
+    };
+    this.confirmed.emit(options);
+  }
+
+  onCancel() {
+    this.cancelled.emit();
+  }
+
+  isLayerSelected(layer: string): boolean {
+    return this.selectedLayers.includes(layer);
+  }
+
+  isBlockSelected(block: string): boolean {
+    return this.selectedBlocks.includes(block);
+  }
+}

--- a/src/app/components/side-nav-menu/blocks/blocks.component.ts
+++ b/src/app/components/side-nav-menu/blocks/blocks.component.ts
@@ -31,7 +31,8 @@ export class BlocksComponent implements OnInit, OnDestroy {
   searchListData: any[] = [];
   searchResultInfo: string;
   isSearchResultDirty = false; // used when search criteria is changed and search result is not updated yet
-
+  hasvectorBlocks: IVectorBlock[] = [];
+  vectorBlocksSet:boolean=true;
 
   
   constructor(private readonly rxCoreService: RxCoreService, private readonly tooltipService: TooltipService, private el: ElementRef) {}
@@ -39,6 +40,18 @@ export class BlocksComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     this.rxCoreService.guiVectorBlocks$.subscribe((blocks) => {
       // this.vectorBlocks = blocks;
+      if(this.vectorBlocksSet)
+      {
+      this.hasvectorBlocks = (blocks || []).filter(
+          (block): block is IVectorBlock =>
+            block &&
+            typeof block.index === 'number' &&
+            typeof block.name === 'string' &&
+            typeof block.state === 'number'
+        );
+         this.vectorBlocksSet=false;
+      }
+    
       this.vectorBlocks = [];
       blocks.forEach((block) => {
         const attributes = RXCore.getBlockAttributes(block.index);
@@ -118,8 +131,11 @@ export class BlocksComponent implements OnInit, OnDestroy {
 
     
     this.rxCoreService.setSelectedVectorBlock(undefined);
-        
-
+        if(this.hasvectorBlocks==null)
+        {
+      localStorage.removeItem("selectedBlocks");
+        }
+   
   }
 
   ngOnDestroy() {

--- a/src/app/components/side-nav-menu/vector-layers/vector-layers.component.ts
+++ b/src/app/components/side-nav-menu/vector-layers/vector-layers.component.ts
@@ -28,8 +28,10 @@ export class VectorLayersComponent implements OnInit {
       //this.canChangeSign = state.numpages && state.isPDF && RXCore.getCanChangeSign();
 
     });
-
-
+    if(!this.vectorLayers)
+    {
+      localStorage.removeItem("selectedLayers");
+    }
   }
 
   onVectorLayersAllSelect(onoff: boolean): void {

--- a/src/app/components/top-nav-menu/top-nav-menu.component.ts
+++ b/src/app/components/top-nav-menu/top-nav-menu.component.ts
@@ -12,6 +12,8 @@ import {Subject, Subscription} from 'rxjs';
 import { SideNavMenuService } from '../side-nav-menu/side-nav-menu.service';
 import { MeasurePanelService } from '../annotation-tools/measure-panel/measure-panel.service';
 import { ActionType } from './type';
+import { FilePreselectionService } from 'src/app/services/file-preselection.service';
+import { FileMetadataService } from 'src/app/services/file-metadata.service';
 
 
 @Component({
@@ -68,7 +70,9 @@ export class TopNavMenuComponent implements OnInit {
     private readonly compareService: CompareService,
     private readonly service: TopNavMenuService,
     private readonly sideNavMenuService: SideNavMenuService,
-    private readonly measurePanelService: MeasurePanelService
+    private readonly measurePanelService: MeasurePanelService,
+    private filePreselectionService: FilePreselectionService,
+    private readonly fileMetadataService:FileMetadataService,
     ) {
   }
 
@@ -91,6 +95,11 @@ export class TopNavMenuComponent implements OnInit {
   }
 
   ngOnInit(): void {
+    this.filePreselectionService.selectedFile$.subscribe((file) => {
+    if (file) {
+      RXCore.openFile(`${RXCore.Config.baseFileURL}${file.file}`);
+    }
+  });
     this.handleIconRotation();
     this._setOptions();
 

--- a/src/app/models/file-metadata.interface.ts
+++ b/src/app/models/file-metadata.interface.ts
@@ -1,0 +1,15 @@
+export interface FileMetadata {
+  filename: string;
+  filesize: string;
+  format: string;
+  thumbnail: string; 
+  layouts: Layout[];
+  layers: string[];
+}
+
+export interface Layout {
+  name: string;
+  blocks: string[];
+}
+
+

--- a/src/app/services/file-metadata.service.ts
+++ b/src/app/services/file-metadata.service.ts
@@ -1,0 +1,40 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable, of } from 'rxjs';
+declare var RxConfig: any;
+export interface FileMetadata {
+  filename: string;
+  filesize: string;
+  format: string;
+  thumbnail: string;
+  layouts?: Array<{
+    name: string;
+    blocks: string[];
+  }>;
+  layers?: string[];
+}
+
+export interface FileSelectionOptions {
+  selectedLayers: string[];
+  selectedBlocks: string[];
+}
+@Injectable({
+  providedIn: 'root'
+})
+export class FileMetadataService {
+ 
+  constructor(private http: HttpClient) {}
+
+  getFileMetadata(fileName: string, width: number = 300, height: number = 300): Observable<FileMetadata> {
+    const url = `${RxConfig.SampleFileMetatadata}&${encodeURIComponent(fileName)}&${width}&${height}`;
+
+    return this.http.get<FileMetadata>(url);
+  }
+
+
+  isCADFile(fileName: string): boolean {
+    const cadExtensions = ['.dwg', '.dgn', '.idw'];
+    const extension = fileName.toLowerCase().substring(fileName.lastIndexOf('.'));
+    return cadExtensions.includes(extension);
+  }
+}

--- a/src/app/services/file-preselection.service.ts
+++ b/src/app/services/file-preselection.service.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@angular/core';
+import { Subject } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class FilePreselectionService {
+
+private selectedFileSubject = new Subject<any>();
+  selectedFile$ = this.selectedFileSubject.asObservable();
+
+  emitSelectedFile(file: any) {
+    this.selectedFileSubject.next(file);
+  }
+ 
+}

--- a/src/assets/scripts/rxconfig.js
+++ b/src/assets/scripts/rxconfig.js
@@ -49,7 +49,8 @@ var RxConfig = (function() {
 
     var PDFLib = baseURLWeb + "pdfjs/build/pdf.js";
     var PDFWorker = baseURLWeb + "pdfjs/build/pdf.worker.js";
-
+    //metadata:
+    var SampleFileMetatadata = baseURLBin+"RxCSISAPI.dll?SampleFileMetadata";
 
     /* config */
 
@@ -113,6 +114,7 @@ var RxConfig = (function() {
         getSignature : getSignature,
         putInitial : putInitial,
         getInitial : getInitial,
+        SampleFileMetatadata:SampleFileMetatadata
     };
 
 })();

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -923,3 +923,12 @@ input[type="radio"] {
     opacity: 1;
     visibility: visible;
 }
+.cdk-overlay-pane.custom-mat-dialog {
+  width: 620px;
+  max-width: 80vw;
+  position: absolute !important;
+  top: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1000;
+}


### PR DESCRIPTION
**CAD File Metadata Pre-Selection Workflow**


FileMetadataModal Integration for CAD Files
Introduced a new FileMetadataModalComponent to display file metadata (e.g., layers and blocks) before opening CAD files.
Implemented conditional display: modal is triggered only for .dwg and similar CAD file types.

**File Metadata Retrieval Service**
Created FileMetadataService to call the backend API (SampleFileMetadata) and fetch detailed metadata for selected files.
Introduced FileMetadata interface to map API response structure, ensuring type safety and clarity.

**File Gallery Enhancements**
Extended handleFileSelect() method in the file-gallery component to:
Open metadata modal for CAD files
Capture user-selected layers and blocks before loading into the viewer
Emit enriched file data using a new FilePreselectionService.

**Viewer State Management**
Created FilePreselectionService to emit selected CAD file metadata and trigger file opening logic from the top-nav-menu component.
Updated onGuiVectorLayers() and onGuiVectorBlocks() to reflect the selected layers and blocks from the modal.

**Backend Integration**
Integrated new backend endpoint (SampleFileMetadata) into rxconfig.js to enable dynamic metadata fetching with support for thumbnail generation.