### PR TITLE
chore: hide annotation and measurement menus for 3D/BIM

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,13 @@
+July 29, 2025
+
+### 1. Annotation and measurement options are now hidden when 3D or BIM files are opened, using an is3D flag check in the _setOptions() method.
+### 2. Introduced visibleOptionsCount getter to control visibility of toolbar elements.
+### 2. UI elements like comment icon, scale display, and mode dropdown are conditionally rendered based on available options.
+
+Updated Files
+src\app\components\top-nav-menu\top-nav-menu.component.html
+src\app\components\top-nav-menu\top-nav-menu.component.ts
+
 July 9, 2025
 
 ### 1. Support to sync scaling/calibration change for different users.

--- a/src/app/components/top-nav-menu/top-nav-menu.component.html
+++ b/src/app/components/top-nav-menu/top-nav-menu.component.html
@@ -610,11 +610,11 @@
     <button (click)="onRemoveWatermarkClick()">Remove Watermark</button>
   </div>
 
-  <div class="top-nav-item current-scale">
+  <div *ngIf="visibleOptionsCount > 1" class="top-nav-item current-scale">
     <span>{{ currentScaleValue }}</span>
   </div>
 
-  <div class="top-nav-item dropdown" *ngIf="fileLength > 0">
+  <div class="top-nav-item dropdown" *ngIf="fileLength > 0 && visibleOptionsCount > 1">
     <rx-dropdown
       [options]="options"
       [value]="selectedValue"
@@ -647,7 +647,7 @@
     <span class="tooltip-text tooltip-bottom">Search</span>
   </div>
   <div
-    *ngIf="fileLength > 0"
+    *ngIf="fileLength > 0 && visibleOptionsCount > 1"
     [ngClass]="{ selected: isActionSelected && actionType === 'Comment' }"
     class="tooltip Comments-icon"
     (click)="onCommentPanelSelect()"

--- a/src/app/components/top-nav-menu/top-nav-menu.component.ts
+++ b/src/app/components/top-nav-menu/top-nav-menu.component.ts
@@ -80,10 +80,11 @@ export class TopNavMenuComponent implements OnInit {
 
 
   private _setOptions(option: any = undefined): void {
+    const is3D = this.guiState?.is3D;
     this.options = [
       { value: GuiMode.View, label: "View" },
-      { value: GuiMode.Annotate, label: "Annotate", hidden: !this.guiConfig.canAnnotate },
-      { value: GuiMode.Measure, label: "Measure", hidden: !this.guiConfig.canAnnotate },
+      { value: GuiMode.Annotate, label: "Annotate", hidden: is3D ||  !this.guiConfig.canAnnotate },
+      { value: GuiMode.Measure, label: "Measure", hidden: is3D ||  !this.guiConfig.canAnnotate },
       { value: GuiMode.Signature, label: "Signature", hidden: !(this.guiConfig.canSignature && this.canChangeSign) },
       { value: GuiMode.Compare, label: "Revision", hidden: !this.guiConfig.canCompare || !this.compareService.isComparisonActive }
     ];
@@ -91,6 +92,9 @@ export class TopNavMenuComponent implements OnInit {
     this.selectedValue = option ? option : this.options[0];
     this.annotationToolsService.setSelectedOption(this.selectedValue);
   }
+   get visibleOptionsCount(): number {
+  return this.options.filter(option => !option.hidden).length;
+}
 
   ngOnInit(): void {
     this.handleIconRotation();


### PR DESCRIPTION
### Dynamic Toolbar Options Based on File Type – Mode Selection Workflow

**Enhanced Option Configuration in _setOptions()**
Introduced is3D flag check to dynamically hide Annotate and Measure options when opening 3D or BIM files.
This ensures irrelevant tools are not shown in the toolbar for non-annotatable file types.

**Added visibleOptionsCount Getter**
Implemented a dedicated getter to calculate the number of visible toolbar options based on current configuration and file type.
This is used to control conditional rendering logic across multiple UI components.

**Conditional Rendering of UI Elements**
Updated toolbar UI to show/hide elements like the mode dropdown, comment icon, and scale display depending on the number of available actions.
Ensures a clean and context-aware UI experience tailored to the selected file format.